### PR TITLE
Let user customize the size of images

### DIFF
--- a/ajax/savecrop.php
+++ b/ajax/savecrop.php
@@ -29,6 +29,7 @@ namespace OCA\Contacts;
 
 require_once 'loghandler.php';
 
+$max_size = (int)\OCP\Config::getUserValue(\OCP\User::getUser(), 'contacts', 'max_size', 400);
 $image = null;
 
 $x1 = (isset($_POST['x1']) && $_POST['x1']) ? $_POST['x1'] : 0;
@@ -76,8 +77,8 @@ if($data) {
 			'savecrop.php, x: '.$x1.' y: '.$y1.' w: '.$w.' h: '.$h,
 			\OCP\Util::DEBUG);
 		if($image->crop($x1, $y1, $w, $h)) {
-			if(($image->width() <= 200 && $image->height() <= 200)
-				|| $image->resize(200)) {
+			if(($image->width() <= $max_size && $image->height() <= $max_size)
+				|| $image->resize($max_size)) {
 
 				// For vCard 3.0 the type must be e.g. JPEG or PNG
 				// For version 4.0 the full mimetype should be used.

--- a/ajax/uploadphoto.php
+++ b/ajax/uploadphoto.php
@@ -33,6 +33,7 @@ $l10n = OCA\Contacts\App::$l10n;
 $contactid = isset($_POST['contactid']) ? $_POST['contactid'] : '';
 $addressbookid = isset($_POST['addressbookid']) ? $_POST['addressbookid'] : '';
 $backend = isset($_POST['backend']) ? $_POST['backend'] : '';
+$max_size = (int)\OCP\Config::getUserValue(\OCP\User::getUser(), 'contacts', 'max_size', 200);
 
 if($contactid == '') {
 	bailOut('Missing contact id.');
@@ -50,8 +51,8 @@ if ($fn) {
 	$image = new OC_Image();
 	sleep(1); // Apparently it needs time to load the data.
 	if($image->loadFromData($data)) {
-		if($image->width() > 400 || $image->height() > 400) {
-			$image->resize(400); // Prettier resizing than with browser and saves bandwidth.
+		if($image->width() > $max_size || $image->height() > $max_size) {
+			$image->resize($max_size); // Prettier resizing than with browser and saves bandwidth.
 		}
 		if(!$image->fixOrientation()) { // No fatal error so we don't bail out.
 			debug('Couldn\'t save correct image orientation: '.$tmpkey);
@@ -98,8 +99,8 @@ if(file_exists($file['tmp_name'])) {
 	$tmpkey = 'contact-photo-'.md5(basename($file['tmp_name']));
 	$image = new OC_Image();
 	if($image->loadFromFile($file['tmp_name'])) {
-		if($image->width() > 400 || $image->height() > 400) {
-			$image->resize(400); // Prettier resizing than with browser and saves bandwidth.
+		if($image->width() > $max_size || $image->height() > $max_size) {
+			$image->resize($max_size); // Prettier resizing than with browser and saves bandwidth.
 		}
 		if(!$image->fixOrientation()) { // No fatal error so we don't bail out.
 			debug('Couldn\'t save correct image orientation: '.$tmpkey);

--- a/ajax/uploadphoto.php
+++ b/ajax/uploadphoto.php
@@ -33,7 +33,7 @@ $l10n = OCA\Contacts\App::$l10n;
 $contactid = isset($_POST['contactid']) ? $_POST['contactid'] : '';
 $addressbookid = isset($_POST['addressbookid']) ? $_POST['addressbookid'] : '';
 $backend = isset($_POST['backend']) ? $_POST['backend'] : '';
-$max_size = (int)\OCP\Config::getUserValue(\OCP\User::getUser(), 'contacts', 'max_size', 200);
+$max_size = (int)\OCP\Config::getUserValue(\OCP\User::getUser(), 'contacts', 'max_size', 400);
 
 if($contactid == '') {
 	bailOut('Missing contact id.');

--- a/js/config.php
+++ b/js/config.php
@@ -36,3 +36,4 @@ echo 'contacts_categories_indexed = '
 	. (OCP\Config::getUserValue($user, 'contacts', 'contacts_categories_indexed', 'no') === 'no'
 	? 'false' : 'true') . ',';
 echo 'lang=\'' . OCP\Config::getUserValue($user, 'core', 'lang', 'en') . '\';';
+echo 'max_size=\'' . OCP\Config::getUserValue($user, 'contacts', 'max_size', 'en') . '\';';

--- a/js/settings.js
+++ b/js/settings.js
@@ -202,4 +202,10 @@ $(document).ready(function() {
 			}
 		}
 	});
+
+	$('#max_size_input').on('change', function(event) {
+		event.preventDefault();
+		OC.Contacts.storage.setPreference('max_size', $(this).val());
+		$('#max_size_value').text($(this).val() + 'px');
+	});
 });

--- a/photo.php
+++ b/photo.php
@@ -25,7 +25,7 @@ $parent = isset($_GET['parent']) ? $_GET['parent'] : null;
 $backend = isset($_GET['backend']) ? $_GET['backend'] : null;
 $etag = null;
 $caching = null;
-$max_size = 170;
+$max_size = (int)\OCP\Config::getUserValue(\OCP\User::getUser(), 'contacts', 'max_size', 200);
 
 if(!$id || $id === 'new') {
 	getStandardImage();

--- a/photo.php
+++ b/photo.php
@@ -25,7 +25,7 @@ $parent = isset($_GET['parent']) ? $_GET['parent'] : null;
 $backend = isset($_GET['backend']) ? $_GET['backend'] : null;
 $etag = null;
 $caching = null;
-$max_size = (int)\OCP\Config::getUserValue(\OCP\User::getUser(), 'contacts', 'max_size', 200);
+$max_size = 170;
 
 if(!$id || $id === 'new') {
 	getStandardImage();

--- a/templates/contacts.php
+++ b/templates/contacts.php
@@ -37,6 +37,11 @@
 						</li>
 					</ul>
 				</div>
+				<div id="max_size">
+				<h2 data-id="max_size" tabindex="0" role="button"><?php p($l->t('Maximum image size')); ?></h2>
+					<input type="range" min="50" max="2000" step="50" name="max_size" id="max_size_input" value="<?php p($_['max_size']) ?>"/>
+					<div id="max_size_value"><?php p($_['max_size']) ?>px</div>
+				</div>
 			</div> <!-- app-settings-content -->
 		</div>
 	</div>


### PR DESCRIPTION
Hi,
I told my friend about OwnCloud and he complained about the bad resolution of the photos of his contacts after syncing them to his smartphone. This was something that I noticed before: My Samsung has a horizontal resolution of about 540px and when I did call somebody the full-width image looked quite screepy. So I decided to look into what is happening there and what could be done.

The result is this branch where the user is able to set the maximum height/width of the photos he is going to upload in the future. There is (afaik) no way to resize the existing images since they are not saved in their original resolution (perhaps the OwnCloud path is saved somewhere). As far as I comprehend [RFC 6350](http://tools.ietf.org/html/rfc6350#section-6.2.4) there is no limitation on image sizes.

Advantages:
- better images

Disadvantages:
- needs more disk space
- needs more time to sync (Setting the maximum size from 200px to 1000px enlarges the VCards from ~70kb to ~1MB). That's why I think it is best to let the user decide what size his images shall have.

ToDos:
- Decide what to do with existing images if the resolution is reduced: Shall they be resized? When?
- Add localization
- Review the changes
