### PR TITLE
Paging contact list

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -56,6 +56,17 @@ $this->create('contacts_address_book', 'addressbook/{backend}/{addressBookId}')
 	)
 	->requirements(array('backend', 'addressBookId'));
 
+$this->create('contacts_address_book_page', 'addressbook/{backend}/{addressBookId}/{page}')
+	->get()
+	->action(
+		function($params) {
+			session_write_close();
+			$dispatcher = new Dispatcher($params);
+			$dispatcher->dispatch('AddressBookController', 'getAddressBook');
+		}
+	)
+	->requirements(array('backend', 'addressBookId'));
+
 $this->create('contacts_address_book_update', 'addressbook/{backend}/{addressBookId}')
 	->post()
 	->action(

--- a/css/contacts.css
+++ b/css/contacts.css
@@ -759,6 +759,22 @@ tbody tr.contact.active, tbody tr.contact:hover {
 	transition: all 0.5s ease-in-out;
 }
 
+#contact-load-more {
+    height: 3em;
+    width: 100%;
+    border-radius: 0;
+    border-width: 0 0 1px 0;
+    border-style: solid;
+    border-color: #DDD;
+    outline: none;
+    display: none;
+}
+
+#contact-load-more.loading {
+    text-indent: -3000px;
+    overflow: hidden;
+}
+
 @media screen and (min-width: 1400px) {
 	#contact > ul.propertylist {
 		-moz-column-count: 3;

--- a/css/contacts.css
+++ b/css/contacts.css
@@ -760,19 +760,19 @@ tbody tr.contact.active, tbody tr.contact:hover {
 }
 
 #contact-load-more {
-    height: 3em;
-    width: 100%;
-    border-radius: 0;
-    border-width: 0 0 1px 0;
-    border-style: solid;
-    border-color: #DDD;
-    outline: none;
-    display: none;
+	height: 3em;
+	width: 100%;
+	-moz-border-radius: 0; -webkit-border-radius: 0; border-radius: 0; 
+	border-width: 0 0 1px 0;
+	border-style: solid;
+	border-color: #DDD;
+	outline: none;
+	display: none;
 }
 
 #contact-load-more.loading {
-    text-indent: -3000px;
-    overflow: hidden;
+	text-indent: -3000px;
+	overflow: hidden;
 }
 
 @media screen and (min-width: 1400px) {

--- a/js/addressbooks.js
+++ b/js/addressbooks.js
@@ -9,6 +9,7 @@ OC.Contacts = OC.Contacts || {};
 		this.storage = storage;
 		this.book = book;
 		this.$template = template;
+	        this.nextPage = 1;
 	}
 
 	AddressBook.prototype.render = function() {
@@ -163,6 +164,11 @@ OC.Contacts = OC.Contacts || {};
 		return this.book.active;
 	};
 
+
+        AddressBook.prototype.getNextPage = function() {
+	    return this.nextPage;
+	}
+
 	/**
 	 * Save an address books active state to data store.
 	 * @param bool state
@@ -224,6 +230,10 @@ OC.Contacts = OC.Contacts || {};
 			$(document).trigger('status.contacts.error', response);
 		});
 	};
+
+    AddressBook.prototype.incrementNextPage = function() {
+	++this.nextPage;
+    }
 
 	/**
 	 * Controls access to address books

--- a/js/addressbooks.js
+++ b/js/addressbooks.js
@@ -9,7 +9,7 @@ OC.Contacts = OC.Contacts || {};
 		this.storage = storage;
 		this.book = book;
 		this.$template = template;
-	        this.nextPage = 1;
+		this.nextPage = 1;
 	}
 
 	AddressBook.prototype.render = function() {
@@ -165,8 +165,8 @@ OC.Contacts = OC.Contacts || {};
 	};
 
 
-        AddressBook.prototype.getNextPage = function() {
-	    return this.nextPage;
+	AddressBook.prototype.getNextPage = function() {
+		return this.nextPage;
 	}
 
 	/**
@@ -231,9 +231,9 @@ OC.Contacts = OC.Contacts || {};
 		});
 	};
 
-    AddressBook.prototype.incrementNextPage = function() {
-	++this.nextPage;
-    }
+	AddressBook.prototype.incrementNextPage = function() {
+		++this.nextPage;
+	}
 
 	/**
 	 * Controls access to address books

--- a/js/app.js
+++ b/js/app.js
@@ -727,7 +727,7 @@ OC.Contacts = OC.Contacts || {
 			});
 			if (!same_group) {
 				self.$rightContent.scrollTop(0);
-		    	}
+			}
 		});
 		// mark items whose title was hid under the top edge as read
 		/*this.$rightContent.scroll(function() {
@@ -1013,14 +1013,14 @@ OC.Contacts = OC.Contacts || {
 			if(wrongKey(event)) {
 				return;
 			}
-		    	toggleSettings();
+			toggleSettings();
 		});
 
 		this.$settings.find('#paging-limit button').on('click keydown',function(event) {
 			if(wrongKey(event)) {
 				return;
 			}
-		    	var limit = parseInt(self.$settings.find('input#set-paging-limit').val());
+			var limit = parseInt(self.$settings.find('input#set-paging-limit').val());
 			// Validate limit to be a valid, positive integer.
 			if (isNaN(limit) || limit < 1) {
 				$(document).trigger('status.contacts.error', {message:'Paging limit must be a positive integer.'});

--- a/js/app.js
+++ b/js/app.js
@@ -184,62 +184,62 @@ OC.Contacts = OC.Contacts || {
 		// Hide the list while populating it.
 		this.$contactList.hide();
 		$.when(this.addressBooks.loadAddressBooks()).then(function(addressBooks) {
-		self.loadContacts(addressBooks);
-	    })
+			self.loadContacts(addressBooks);
+		})
 		.fail(function(response) {
-		    console.log(response.message);
-		    $(document).trigger('status.contacts.error', response);
+			console.log(response.message);
+			$(document).trigger('status.contacts.error', response);
 		});
 		$(OC.Tags).on('change', this.groups.categoriesChanged)
 		this.bindEvents();
 		this.$toggleAll.show();
 		this.hideActions();
 	},
-    loadContacts:function(addressBooks) {
-	var self = this;
-			var deferreds = $(addressBooks).map(function(i, elem) {
-	    var result = self.contacts.loadContacts(this.getBackend(), this.getId(), this.isActive(), this.getNextPage());
-	    this.incrementNextPage();
-	    return result;
+	loadContacts:function(addressBooks) {
+		var self = this;
+		var deferreds = $(addressBooks).map(function(i, elem) {
+			var result = self.contacts.loadContacts(this.getBackend(), this.getId(), this.isActive(), this.getNextPage());
+			this.incrementNextPage();
+			return result;
+		});
+		// This little beauty is from http://stackoverflow.com/a/6162959/373007 ;)
+		$.when.apply(null, deferreds.get()).then(function(response) {
+			self.contacts.setSortOrder(contacts_sortby);
+			self.$contactList.show();
+			$('#contact-load-more').show().removeClass('loading');
+			$(document).trigger('status.contacts.loaded', {
+				numcontacts: self.contacts.length
 			});
-			// This little beauty is from http://stackoverflow.com/a/6162959/373007 ;)
-			$.when.apply(null, deferreds.get()).then(function(response) {
-				self.contacts.setSortOrder(contacts_sortby);
-				self.$contactList.show();
-	    $('#contact-load-more').show().removeClass('loading');
-				$(document).trigger('status.contacts.loaded', {
-					numcontacts: self.contacts.length
-				});
-				self.loading(self.$rightContent, false);
-				// TODO: Move this to event handler
-				self.groups.selectGroup({id:contacts_lastgroup});
-				var id = $.QueryString['id']; // Keep for backwards compatible links.
-				if(!id) {
-					id = window.location.hash.substr(1);
-				}
-				console.log('Groups loaded, id from url:', id);
-				if(id) {
-					self.openContact(id);
-				}
-				if(!contacts_properties_indexed) {
-					// Wait a couple of mins then check if contacts are indexed.
-					setTimeout(function() {
-							$.when($.post(OC.Router.generate('contacts_index_properties')))
-								.then(function(response) {
-									if(!response.isIndexed) {
-										OC.notify({message:t('contacts', 'Indexing contacts'), timeout:20});
-									}
-								});
-					}, 10000);
-				} else {
-					console.log('contacts are indexed.');
-				}
-			}).fail(function(response) {
-				console.warn(response);
-				self.$rightContent.removeClass('loading');
-				message = t('contacts', 'Unrecoverable error loading address books: {msg}', {msg:response.message});
-				OC.dialogs.alert(message, t('contacts', 'Error.'));
-			});
+			self.loading(self.$rightContent, false);
+			// TODO: Move this to event handler
+			self.groups.selectGroup({id:contacts_lastgroup});
+			var id = $.QueryString['id']; // Keep for backwards compatible links.
+			if(!id) {
+				id = window.location.hash.substr(1);
+			}
+			console.log('Groups loaded, id from url:', id);
+			if(id) {
+				self.openContact(id);
+			}
+			if(!contacts_properties_indexed) {
+				// Wait a couple of mins then check if contacts are indexed.
+				setTimeout(function() {
+					$.when($.post(OC.Router.generate('contacts_index_properties')))
+						.then(function(response) {
+							if(!response.isIndexed) {
+								OC.notify({message:t('contacts', 'Indexing contacts'), timeout:20});
+							}
+						});
+				}, 10000);
+			} else {
+				console.log('contacts are indexed.');
+			}
+		}).fail(function(response) {
+			console.warn(response);
+			self.$rightContent.removeClass('loading');
+			message = t('contacts', 'Unrecoverable error loading address books: {msg}', {msg:response.message});
+			OC.dialogs.alert(message, t('contacts', 'Error.'));
+		});
 	},
 	loading:function(obj, state) {
 		$(obj).toggleClass('loading', state);
@@ -695,7 +695,7 @@ OC.Contacts = OC.Contacts || {
 		// Group selected, only show contacts from that group
 		$(document).bind('status.group.selected', function(e, result) {
 			console.log('status.group.selected', result);
-		    var same_group = self.currentgroup == result.id;
+			var same_group = self.currentgroup == result.id;
 			self.currentgroup = result.id;
 			// Close any open contact.
 			if(self.currentid) {
@@ -725,9 +725,9 @@ OC.Contacts = OC.Contacts || {
 				$(document).trigger('status.contacts.error', response);
 				done = true;
 			});
-		    if (!same_group) {
-			self.$rightContent.scrollTop(0);
-		    }
+			if (!same_group) {
+				self.$rightContent.scrollTop(0);
+		    	}
 		});
 		// mark items whose title was hid under the top edge as read
 		/*this.$rightContent.scroll(function() {
@@ -777,10 +777,10 @@ OC.Contacts = OC.Contacts || {
 			}
 		});
 
-	    $('#contact-load-more').on('click', function(event) {
-		$(this).addClass('loading');
-		self.loadContacts(self.addressBooks.addressBooks);
-	    });
+		$('#contact-load-more').on('click', function(event) {
+			$(this).addClass('loading');
+			self.loadContacts(self.addressBooks.addressBooks);
+		});
 
 		this.$ninjahelp.find('.close').on('click keydown',function(event) {
 			if(wrongKey(event)) {
@@ -1027,7 +1027,7 @@ OC.Contacts = OC.Contacts || {
 				return;
 			}
 			self.storage.setPreference('paging_limit', limit);
-		    	toggleSettings();
+			toggleSettings();
 		});
 
 		var addContact = function() {

--- a/js/contacts.js
+++ b/js/contacts.js
@@ -2474,15 +2474,15 @@ OC.Contacts = OC.Contacts || {};
 	* @param boolean isActive
 	* @param integer page
 	*/
-    ContactList.prototype.loadContacts = function(backend, addressBookId, isActive, page) {
+	ContactList.prototype.loadContacts = function(backend, addressBookId, isActive, page) {
 		if(!isActive) {
 			return;
 		}
 		var self = this,
 			contacts;
-	if (!page || isNaN(page)) {
-	    page = 1;
-	}
+		if (!page || isNaN(page)) {
+			page = 1;
+		}
 
 		return $.when(self.storage.getAddressBook(backend, addressBookId, page))
 			.then(function(response) {

--- a/js/contacts.js
+++ b/js/contacts.js
@@ -2471,15 +2471,20 @@ OC.Contacts = OC.Contacts || {};
 	* Load contacts
 	* @param string backend Name of the backend ('local', 'ldap' etc.)
 	* @param string addressBookId
+	* @param boolean isActive
+	* @param integer page
 	*/
-	ContactList.prototype.loadContacts = function(backend, addressBookId, isActive) {
+    ContactList.prototype.loadContacts = function(backend, addressBookId, isActive, page) {
 		if(!isActive) {
 			return;
 		}
 		var self = this,
 			contacts;
+	if (!page || isNaN(page)) {
+	    page = 1;
+	}
 
-		return $.when(self.storage.getAddressBook(backend, addressBookId, false))
+		return $.when(self.storage.getAddressBook(backend, addressBookId, page))
 			.then(function(response) {
 			console.log('ContactList.loadContacts - fetching', response);
 			if(!response.error) {

--- a/js/storage.js
+++ b/js/storage.js
@@ -171,6 +171,7 @@ OC.Contacts = OC.Contacts || {};
 	 *
 	 * @param string backend
 	 * @param string addressBookId Address book ID
+	 * @param string page Contacts page number
 	 * @return
 	 * An array containing contact data e.g.:
 	 * {
@@ -185,20 +186,26 @@ OC.Contacts = OC.Contacts || {};
 	 * 	data: //array of VCard data
 	 * }
 	 */
-	Storage.prototype.getAddressBook = function(backend, addressBookId) {
+    Storage.prototype.getAddressBook = function(backend, addressBookId, page) {
 		var headers = {},
 			data,
 			key = 'contacts::' + backend + '::' + addressBookId,
-			defer = $.Deferred();
+	                defer = $.Deferred(),
+	                route = 'contacts_address_book',
+	                params = {backend: backend, addressBookId: addressBookId};
 
 		if(OC.localStorage.hasItem(key)) {
 			data = OC.localStorage.getItem(key);
 			headers['If-None-Match'] = data.Etag;
 		}
+	        if (page) {
+		        route += '_page';
+		        params['page'] = page;
+		}
 		$.when(this.requestRoute(
-			'contacts_address_book',
+			route,
 			'GET',
-			{backend: backend, addressBookId: addressBookId},
+		        params,
 			'',
 			headers
 		))

--- a/js/storage.js
+++ b/js/storage.js
@@ -186,26 +186,26 @@ OC.Contacts = OC.Contacts || {};
 	 * 	data: //array of VCard data
 	 * }
 	 */
-    Storage.prototype.getAddressBook = function(backend, addressBookId, page) {
+	Storage.prototype.getAddressBook = function(backend, addressBookId, page) {
 		var headers = {},
 			data,
 			key = 'contacts::' + backend + '::' + addressBookId,
-	                defer = $.Deferred(),
-	                route = 'contacts_address_book',
-	                params = {backend: backend, addressBookId: addressBookId};
+			defer = $.Deferred(),
+			route = 'contacts_address_book',
+			params = {backend: backend, addressBookId: addressBookId};
 
 		if(OC.localStorage.hasItem(key)) {
 			data = OC.localStorage.getItem(key);
 			headers['If-None-Match'] = data.Etag;
 		}
-	        if (page) {
-		        route += '_page';
-		        params['page'] = page;
+		if (page) {
+			route += '_page';
+			params['page'] = page;
 		}
 		$.when(this.requestRoute(
 			route,
 			'GET',
-		        params,
+			params,
 			'',
 			headers
 		))

--- a/lib/app.php
+++ b/lib/app.php
@@ -162,4 +162,13 @@ class App {
 		return $addressBook->getChild($id);
 	}
 
+  	/**
+	 * @brief gets the limit for addressbook contacts paging.
+	 * @return boolean
+	 */
+	public function getPagingLimit() {
+        $default_limit = 15;
+        $limit = \OCP\Config::getUserValue(\OCP\User::getUser(), 'contacts', 'paging_limit', $default_limit);
+        return (is_numeric($limit) && $limit > 0) ? round($limit) : $default_limit;
+	}
 }

--- a/lib/app.php
+++ b/lib/app.php
@@ -167,8 +167,8 @@ class App {
 	 * @return boolean
 	 */
 	public function getPagingLimit() {
-        $default_limit = 15;
-        $limit = \OCP\Config::getUserValue(\OCP\User::getUser(), 'contacts', 'paging_limit', $default_limit);
-        return (is_numeric($limit) && $limit > 0) ? round($limit) : $default_limit;
+		$default_limit = 15;
+		$limit = \OCP\Config::getUserValue(\OCP\User::getUser(), 'contacts', 'paging_limit', $default_limit);
+		return (is_numeric($limit) && $limit > 0) ? round($limit) : $default_limit;
 	}
 }

--- a/lib/controller/addressbookcontroller.php
+++ b/lib/controller/addressbookcontroller.php
@@ -63,17 +63,17 @@ class AddressBookController extends Controller {
 
 		$addressBook = $this->app->getAddressBook($params['backend'], $params['addressBookId']);
 		$lastModified = $addressBook->lastModified();
-        $paging_limit = $this->app->getPagingLimit();
+		$paging_limit = $this->app->getPagingLimit();
 		$etag = null;
 		$response = new JSONResponse();
 
 		if(!is_null($lastModified)) {
 			//$response->addHeader('Cache-Control', 'private, must-revalidate');
 			$response->setLastModified(\DateTime::createFromFormat('U', $lastModified) ?: null);
-            $to_hash = $lastModified;
-            if (isset($params['page'])) {
-                $to_hash .= '_' . $params['page'] . '_' . $paging_limit;
-            }
+			$to_hash = $lastModified;
+			if (isset($params['page'])) {
+				$to_hash .= '_' . $params['page'] . '_' . $paging_limit;
+			}
 			$etag = md5($to_hash);
 			$response->setETag($etag);
 		}
@@ -85,13 +85,13 @@ class AddressBookController extends Controller {
 			return $response->setStatus(Http::STATUS_NOT_MODIFIED);
 		} else {
 			$contacts = array();
-            if (isset($params['page']) && is_numeric($params['page'])) {
-                $offset = ((int)$params['page'] - 1) * $paging_limit;
-                $rawContacts = $addressBook->getChildren($paging_limit, $offset);
-            }
-            else {
-                $rawContacts = $addressBook->getChildren();
-            }
+			if (isset($params['page']) && is_numeric($params['page'])) {
+				$offset = ((int)$params['page'] - 1) * $paging_limit;
+				$rawContacts = $addressBook->getChildren($paging_limit, $offset);
+			}
+			else {
+				$rawContacts = $addressBook->getChildren();
+			}
 			foreach($rawContacts as $i => $contact) {
 				$result = JSONSerializer::serializeContact($contact);
 				if($result !== null) {

--- a/lib/controller/pagecontroller.php
+++ b/lib/controller/pagecontroller.php
@@ -68,6 +68,7 @@ class PageController extends Controller {
 			'adr_types' => $adr_types,
 			'impp_types' => $impp_types,
 			'im_protocols' => $im_protocols,
+            'paging_limit' => $this->app->getPagingLimit(),
 		));
 
 		return $response;

--- a/lib/controller/pagecontroller.php
+++ b/lib/controller/pagecontroller.php
@@ -68,7 +68,7 @@ class PageController extends Controller {
 			'adr_types' => $adr_types,
 			'impp_types' => $impp_types,
 			'im_protocols' => $im_protocols,
-            'paging_limit' => $this->app->getPagingLimit(),
+			'paging_limit' => $this->app->getPagingLimit(),
 		));
 
 		return $response;

--- a/templates/contacts.php
+++ b/templates/contacts.php
@@ -37,6 +37,11 @@
 						</li>
 					</ul>
 				</div>
+				<div id="paging-limit">
+					<h2 data-id="paging-limit" tabindex="0" role="button"><?php p($l->t('Paging Limit')); ?></h2>
+					<input type="text" tabindex="0" autofocus id="set-paging-limit" title="<?php p($l->t('Contacts to load per addressbook')); ?>" value="<?php p($_['paging_limit']); ?>" />
+					<button class="primary"><?php p($l->t('Save')) ?></button>
+				</div>
 			</div> <!-- app-settings-content -->
 		</div>
 	</div>
@@ -87,6 +92,7 @@
 			<tbody>
 			</tbody>
 		</table>
+		<input type="button" id="contact-load-more" value="Load more" />
 		<div class="hidden popup" id="ninjahelp">
 			<a class="close" tabindex="0" role="button" title="<?php p($l->t('Close')); ?>"></a>
 			<h2><?php p($l->t('Keyboard shortcuts')); ?></h2>


### PR DESCRIPTION
Fix for https://github.com/owncloud/contacts/issues/136 and https://github.com/owncloud/contacts/issues/334 that adds basic pagination for the contacts list.

When the contact list loads, it retrieves 15 contacts from each address book. Each time the new "load more" button is clicked, 15 more contacts will be retrieved from each address book, until there are no more contacts left to load.

While the paging limit defaults to 15 contacts per address book, it can be changed from the contacts settings.

Client side caching of contacts still operates, but cached contacts are now invalidated when the paging limit is changed as well as when the address book is modified.

While I see that pagination isn't under consideration because of other speed improvements to the contacts app, it was a feature that we required, and it seems that some others are interested in it too, so I thought that I would leave the changes here for consideration :) 
