### PR TITLE
Fix X-EVOLUTION-FILE-AS escape

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -15,6 +15,7 @@ use \OC\AppFramework\Core\API;
 \Sabre\VObject\Property::$classMap['TEL']		= '\OC\VObject\StringProperty';
 \Sabre\VObject\Property::$classMap['IMPP']		= '\OC\VObject\StringProperty';
 \Sabre\VObject\Property::$classMap['URL']		= '\OC\VObject\StringProperty';
+\Sabre\VObject\Property::$classMap['X-EVOLUTION-FILE-AS'] = '\OC\VObject\StringProperty';
 \Sabre\VObject\Property::$classMap['N']			= '\OC\VObject\CompoundProperty';
 \Sabre\VObject\Property::$classMap['ADR']		= '\OC\VObject\CompoundProperty';
 \Sabre\VObject\Property::$classMap['GEO']		= '\OC\VObject\CompoundProperty';


### PR DESCRIPTION
@smcv: Forwarding your proposal (updated for oC 6) via a pull request, (hopefully) full context provided bellow.

Evolution defaults to the form "X-EVOLUTION-FILE-AS:Bloggs\, Joe", and
since Evolution uses this field as the contacts' displayed name, it's
highly visible when ownCloud turns it into
"X-EVOLUTION-FILE-AS:Bloggs\, Joe".

https://github.com/owncloud/contacts/issues/42#issuecomment-28776546

When interacting with Evolution-Data-Server (which I think MeeGo might
use), the same incorrect escaping applies to X-EVOLUTION-FILE-AS. This
is a non-standard field, but it's highly visible for Evolution users,
since it's used as the default displayed name for contacts there.

https://github.com/owncloud/core/issues/2335#issuecomment-32130820

Bug-Debian: http://bugs.debian.org/735112
