### PR TITLE
remove %appswebroot% as it is completely useless

### DIFF
--- a/css/contacts.css
+++ b/css/contacts.css
@@ -251,7 +251,7 @@ span.ui-icon { margin: 1px 3px 10px 0px; }
 	text-indent: 18px;
 }
 
-/* TODO: Use @import url('%appswebroot%/contacts/css/[no-]svg.css); instead. */
+/* TODO: Use @import url('../css/[no-]svg.css); instead. */
 
 /*.no-svg .add { background-image:url('%webroot%/core/img/actions/add.png'); }*/
 .no-svg .delete { background-image:url('%webroot%/core/img/actions/delete.png'); }
@@ -264,9 +264,9 @@ span.ui-icon { margin: 1px 3px 10px 0px; }
 .no-svg .export, .no-svg .shared { background-image:url('%webroot%/core/img/actions/shared.png'); }
 .no-svg .globe { background-image:url('%webroot%/core/img/actions/public.png'); }
 .no-svg .settings { background-image:url('%webroot%/core/img/actions/settings.svg'); }
-.no-svg .starred { background-image:url('%appswebroot%/contacts/img/starred.png'); background-size: contain; }
-.no-svg .checked { background-image:url('%appswebroot%/contacts/img/checkmark-green.png'); }
-.no-svg .checked.disabled { background-image:url('%appswebroot%/contacts/img/checkmark-gray.png'); cursor: default; }
+.no-svg .starred { background-image:url('../img/starred.png'); background-size: contain; }
+.no-svg .checked { background-image:url('../img/checkmark-green.png'); }
+.no-svg .checked.disabled { background-image:url('../img/checkmark-gray.png'); cursor: default; }
 
 .svg .action.text, .svg .icon.text, .svg .svg.text {
 	background-size: 16px 16px;
@@ -285,9 +285,9 @@ span.ui-icon { margin: 1px 3px 10px 0px; }
 .svg .export,.svg .shared { background-image:url('%webroot%/core/img/actions/shared.svg'); }
 .svg .globe { background-image:url('%webroot%/core/img/actions/public.svg'); }
 .svg .settings { background-image:url('%webroot%/core/img/actions/settings.svg'); }
-.svg .starred { background-image:url('%appswebroot%/contacts/img/starred.svg'); background-size: contain; }
-.svg .checked { background-image:url('%appswebroot%/contacts/img/checkmark-green.svg'); }
-.svg .checked.disabled { background-image:url('%appswebroot%/contacts/img/checkmark-gray.svg'); cursor: default; }
+.svg .starred { background-image:url('../img/starred.svg'); background-size: contain; }
+.svg .checked { background-image:url('../img/checkmark-green.svg'); }
+.svg .checked.disabled { background-image:url('../img/checkmark-gray.svg'); cursor: default; }
 
 .transparent{ opacity: 0.6; }
 .float { float: left; display: inline-block; width: auto; }
@@ -595,13 +595,13 @@ input[type=checkbox].propertytype { width: 10px; }
 	padding-left: 20px;
 	font-weight: normal;
 }
-.no-svg .favorite { display: inline-block; float: left; height: 20px; width: 20px; background-image:url('%appswebroot%/contacts/img/inactive_star.png'); }
-.no-svg .favorite.active, .favorite:hover { background-image:url('%appswebroot%/contacts/img/active_star.png'); }
-.no-svg .favorite.inactive { background-image:url('%appswebroot%/contacts/img/inactive_star.png'); }
+.no-svg .favorite { display: inline-block; float: left; height: 20px; width: 20px; background-image:url('../img/inactive_star.png'); }
+.no-svg .favorite.active, .favorite:hover { background-image:url('../img/active_star.png'); }
+.no-svg .favorite.inactive { background-image:url('../img/inactive_star.png'); }
 
-.svg .favorite { display: inline-block; float: left; height: 20px; width: 20px; background-image:url('%appswebroot%/contacts/img/inactive_star.svg'); background-size:contain; }
-.svg .favorite.active, .favorite:hover { background-image:url('%appswebroot%/contacts/img/active_star.svg');	}
-.svg .favorite.inactive { background-image:url('%appswebroot%/contacts/img/inactive_star.svg'); background-size:contain; }
+.svg .favorite { display: inline-block; float: left; height: 20px; width: 20px; background-image:url('../img/inactive_star.svg'); background-size:contain; }
+.svg .favorite.active, .favorite:hover { background-image:url('../img/active_star.svg');	}
+.svg .favorite.inactive { background-image:url('../img/inactive_star.svg'); background-size:contain; }
 
 #app-content {
 	top: 44px;

--- a/css/jquery.ocaddnew.css
+++ b/css/jquery.ocaddnew.css
@@ -90,7 +90,7 @@
 
 .oc-addnew .create-button {
         border-radius: 0;
-        background-image: url('%appswebroot%/contacts/img/checkmark-gray.svg');
+        background-image: url('../img/checkmark-gray.svg');
         border-top-right-radius: 5px; 
         border-bottom-right-radius: 5px; 
 }


### PR DESCRIPTION
Please review @tanghus @jbtbnl @babelouest 

Next we need to change the icons which use %webroot% to use the newly defined CSS rules from core – but I’ll send a post to the mailing list about that.
