### PR TITLE
added VALARM to birthday events

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -32,11 +32,8 @@ namespace OCA\Contacts;
 \OCP\Util::connectHook('OC_Calendar', 'getEvents', 'OCA\Contacts\Hooks', 'getBirthdayEvents');
 \OCP\Util::connectHook('OC_Calendar', 'getSources', 'OCA\Contacts\Hooks', 'getCalenderSources');
 
-$url = \OC::$server->getRequest()->server['REQUEST_URI'];
-
-if (preg_match('%index.php/apps/files(/.*)?%', $url)) {
-	\OCP\Util::addscript('contacts', 'loader');
-}
+\OCP\Util::addscript('contacts', 'loader');
+\OCP\Util::addscript('contacts', 'admin');
 
 \OC::$server->getSearch()->registerProvider('OCA\Contacts\Search\Provider', array('apps' => array('contacts')));
 \OCP\Share::registerBackend('contact', 'OCA\Contacts\Share\Contact');

--- a/lib/contact.php
+++ b/lib/contact.php
@@ -783,6 +783,9 @@ class Contact extends VObject\VCard implements IPIMObject {
 			$vEvent->{'RRULE'} = 'FREQ=YEARLY';
 			$vEvent->{'SUMMARY'} = $title . ' (' . $date->format('Y') . ')';
 			$vEvent->{'TRANSP'} = 'TRANSPARENT';
+			$alarm = \Sabre\Vobject\Component::create('VALARM');
+			$alarm->TRIGGER = '-PT0M'; //is there a way to make this configurable?
+			$vEvent->add($alarm);
 			$appInfo = \OCP\App::getAppInfo('contacts');
 			$appVersion = \OCP\App::getAppVersion('contacts');
 			$vCal->PRODID = '-//ownCloud//NONSGML '.$appInfo['name'].' '.$appVersion.'//EN';

--- a/lib/contact.php
+++ b/lib/contact.php
@@ -783,10 +783,11 @@ class Contact extends VObject\VCard implements IPIMObject {
 			$vEvent->{'RRULE'} = 'FREQ=YEARLY';
 			$vEvent->{'SUMMARY'} = $title . ' (' . $date->format('Y') . ')';
 			$vEvent->{'TRANSP'} = 'TRANSPARENT';
-			$alarm = \Sabre\Vobject\Component::create('VALARM');
-			$alarm->TRIGGER = '-PT0M';
-			$alarm->{'ACTION'} = 'DISPLAY';
-			$alarm->{'DESCRIPTION'} = $vevent->{'SUMMARY'};
+			$alarm = $vCal->createComponent('VALARM');
+			$alarm->{'TRIGGER'} = '-PT0M';
+			$alarm->add($vCal->createProperty('TRIGGER', '-PT0M', ['VALUE' => 'DURATION']));
+			$alarm->add($vCal->createProperty('ACTION', 'DISPLAY'));
+			$alarm->add($vCal->createProperty('DESCRIPTION', $title . ' (' . $date->format('Y') . ')'));
 			$vEvent->add($alarm);
 			$appInfo = \OCP\App::getAppInfo('contacts');
 			$appVersion = \OCP\App::getAppVersion('contacts');

--- a/lib/contact.php
+++ b/lib/contact.php
@@ -767,7 +767,9 @@ class Contact extends VObject\VCard implements IPIMObject {
 			$vevent->{'RRULE'} = 'FREQ=YEARLY';
 			$vevent->{'SUMMARY'} = $title . ' (' . $date->format('Y') . ')';
 			$alarm = \Sabre\Vobject\Component::create('VALARM');
-			$alarm->TRIGGER = '-PT0M'; //is there a way to make this configurable?
+			$alarm->{'TRIGGER'} = '-PT0M';
+			$alarm->{'ACTION'} = 'DISPLAY';
+			$alarm->{'DESCRIPTION'} = $vevent->{'SUMMARY'};
 			$vevent->add($alarm);
 			$vcal = \Sabre\VObject\Component::create('VCALENDAR');
 			$vcal->VERSION = '2.0';

--- a/lib/contact.php
+++ b/lib/contact.php
@@ -766,6 +766,9 @@ class Contact extends VObject\VCard implements IPIMObject {
 			$vevent->{'UID'} = $this->UID;
 			$vevent->{'RRULE'} = 'FREQ=YEARLY';
 			$vevent->{'SUMMARY'} = $title . ' (' . $date->format('Y') . ')';
+			$alarm = \Sabre\Vobject\Component::create('VALARM');
+			$alarm->TRIGGER = '-PT0M'; //is there a way to make this configurable?
+			$vevent->add($alarm);
 			$vcal = \Sabre\VObject\Component::create('VCALENDAR');
 			$vcal->VERSION = '2.0';
 			$appinfo = \OCP\App::getAppInfo('contacts');

--- a/lib/contact.php
+++ b/lib/contact.php
@@ -784,7 +784,9 @@ class Contact extends VObject\VCard implements IPIMObject {
 			$vEvent->{'SUMMARY'} = $title . ' (' . $date->format('Y') . ')';
 			$vEvent->{'TRANSP'} = 'TRANSPARENT';
 			$alarm = \Sabre\Vobject\Component::create('VALARM');
-			$alarm->TRIGGER = '-PT0M'; //is there a way to make this configurable?
+			$alarm->TRIGGER = '-PT0M';
+			$alarm->{'ACTION'} = 'DISPLAY';
+			$alarm->{'DESCRIPTION'} = $vevent->{'SUMMARY'};
 			$vEvent->add($alarm);
 			$appInfo = \OCP\App::getAppInfo('contacts');
 			$appVersion = \OCP\App::getAppVersion('contacts');

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -10,7 +10,6 @@
  * later.
  */
 
-script('contacts', 'admin')
 ?>
 
 <div class="section">


### PR DESCRIPTION
I did this small change for my owncloud installation, because I want to get a reminder on my mobile for contact birthdays.

Some devices might generate audible ALARMs at 0 o'clock from them, despite the VCALENDAR entry saying it should only display something. So it might be a good idea to make this optional or the offset configurable.. for example changing the trigger to PT12H would display the alarm at noon. 
Currently I can't see any options for the contacts app, so maybe this is not feasible either. 

Anyway, for me this works fine and I wanted to offer this change to you.
