### PR TITLE
Add support for starring contacts with davdroid (uses X-DAVDROID-STARRED)

### DIFF
--- a/lib/utils/properties.php
+++ b/lib/utils/properties.php
@@ -57,7 +57,8 @@ Class Properties {
 	 */
 	public static $index_properties = array(
 		'BDAY', 'UID', 'N', 'FN', 'TITLE', 'ROLE', 'NOTE', 'NICKNAME',
-		'ORG', 'CATEGORIES', 'EMAIL', 'TEL', 'IMPP', 'ADR', 'URL', 'GEO');
+		'ORG', 'CATEGORIES', 'EMAIL', 'TEL', 'IMPP', 'ADR', 'URL', 'GEO',
+		'X-DAVDROID-STARRED');
 
 	/**
 	 * Get options for IMPP properties


### PR DESCRIPTION
davdroid uses X-DAVDROID-STARRED to store whether a contact is favorite (or starred) in Android.
