### PR TITLE
remove unneeded icon class

### DIFF
--- a/js/groups.js
+++ b/js/groups.js
@@ -689,7 +689,7 @@ OC.Contacts = OC.Contacts || {};
 				$elem.data('obj', self);
 				$elem.data('rawname', t('contacts', 'Favorites'));
 				if(!$elem.find('.starred').length) {
-					$elem.data('contacts', contacts).find('.numcontacts').before('<span class="icon icon-starred starred action" />');
+					$elem.data('contacts', contacts).find('.numcontacts').before('<span class="icon-starred starred action" />');
 				}
 				$elem.droppable({
 							drop: self.contactDropped,


### PR DESCRIPTION
As per the change by @jbtbnl in https://github.com/owncloud/core/pull/7382 the extra icon class is not needed anymore.

Please review @owncloud/designers @tanghus 
