### PR TITLE
Change "vcardcountry" to "c" for HOME ADR

### DIFF
--- a/formats/backend_ldap_inet_org_person_connector.xml
+++ b/formats/backend_ldap_inet_org_person_connector.xml
@@ -42,7 +42,7 @@
 			<ldif_entry vcard_position="3" name="l"/>
 			<ldif_entry vcard_position="4" name="st"/>
 			<ldif_entry vcard_position="5" name="postalcode"/>
-			<ldif_entry vcard_position="6" name="vcardcountry" unique="true"/>
+			<ldif_entry vcard_position="6" name="c" unique="true"/>
 		</vcard_entry>
     
 		<vcard_entry property="CATEGORIES" enabled="true">


### PR DESCRIPTION
Instead of "vcardcountry", "c" is used for "RFC2256: ISO-3166 country 2-letter code" in objectClass "inetOrgPerson".
