### PR TITLE
correct selection of current type for multi-type parameters: #536

### DIFF
--- a/js/contacts.js
+++ b/js/contacts.js
@@ -1452,7 +1452,7 @@ OC.Contacts = OC.Contacts || {};
 								}
 								else if(param.toUpperCase() === 'TYPE') {
 									for(var etype in property.parameters[param]) {
-										if(!property.parameters[param].hasOwnProperty(etype)) {
+										if(property.parameters[param].hasOwnProperty(etype)) {
 											var found = false;
 											var et = property.parameters[param][etype];
 											if(typeof et !== 'string') {


### PR DESCRIPTION
This check was exactly the wrong way around, so the code to select the appropriate type wouldn't run when it was actually needed. Should fix #536.
