### PR TITLE
fix caldav when the calendar app is only enabled for specific groups

### DIFF
--- a/appinfo/remote.php
+++ b/appinfo/remote.php
@@ -22,7 +22,9 @@
  *
  */
 
-OCP\App::checkAppEnabled('contacts');
+if (!\OC::$server->getAppManager()->isInstalled('contacts')) {
+	throw new Exception('App not installed: contacts');
+}
 
 if (substr(OCP\Util::getRequestUri(), 0, strlen(OC_App::getAppWebPath('contacts').'/carddav.php'))
 	=== OC_App::getAppWebPath('contacts').'/carddav.php'
@@ -70,6 +72,10 @@ $server->addPlugin(new \Sabre\DAVACL\Plugin());
 $server->addPlugin(new \Sabre\DAV\Browser\Plugin(false)); // Show something in the Browser, but no upload
 $server->addPlugin(new \Sabre\CardDAV\VCFExportPlugin());
 $server->addPlugin(new OC_Connector_Sabre_ExceptionLoggerPlugin('carddav'));
+$server->addPlugin(new \OC\Connector\Sabre\AppEnabledPlugin(
+	'contacts',
+	OC::$server->getAppManager()
+));
 
 if (defined('DEBUG') && DEBUG) {
 	$server->debugExceptions = true;


### PR DESCRIPTION
Since checking if an app is enabled requires a user to be logged in we need to postpone those checks until after the *DAV auth is handled.

Requires owncloud/core#9962
