### PR TITLE
Use correct method to extract image from vcard

### DIFF
--- a/lib/utils/properties.php
+++ b/lib/utils/properties.php
@@ -311,8 +311,8 @@ Class Properties {
 				$app = new App();
 				$vcard = $app->getContact($backendName, $addressBookId, $contactId);
 			}
-			$image = $vcard->getPhoto();
-			if (is_null($image)) {
+			$image = new \OCP\Image();
+			if (!isset($vcard->PHOTO) || !$image->loadFromBase64((string)$vcard->PHOTO)) {
 				return false;
 			}
 		}


### PR DESCRIPTION
It was incorrectly assumed, that `$vcard` is always an `OCA\Contacts\Contact` (which is true when the contacts app is rendered) but when called from the `contactUpdated` hook, it actually is a `OCA\Contacts\VObject\VCard`.

Fixes owncloud/contacts#585
