### PR TITLE
Fix cacheThumbnail if no $vcard was passed

### DIFF
--- a/lib/utils/properties.php
+++ b/lib/utils/properties.php
@@ -328,6 +328,11 @@ Class Properties {
 			if (is_null($vCard)) {
 				$app = new App();
 				$vCard = $app->getContact($backendName, $addressBookId, $contactId);
+				if (isset($vCard['carddata'])) {
+					$vCard = \Sabre\VObject\Reader::read($vCard['carddata']);
+				} else {
+					$vCard = $vCard['vcard'];
+				}
 			}
 			$image = new \OCP\Image();
 			if (!isset($vCard->PHOTO) || !$image->loadFromBase64((string)$vCard->PHOTO)) {


### PR DESCRIPTION
This fixes a type confusion. `getContact` does not return a VCard-object, but an array containing either the VCard mapped to 'vcard' or the string representation of the VCard in 'carddata'.

Note that nowhere in the current codebase is `cacheThumbnail` called without the `$vcard` argument or an argument which could be `null`, so this is not strictly speaking a bug, but dead code which doesn't work.
