### PR TITLE
Show preferred value in contacts list

### DIFF
--- a/js/contacts.js
+++ b/js/contacts.js
@@ -1757,6 +1757,7 @@ OC.Contacts = OC.Contacts || {};
 				}
 				for(var param in prop.parameters) {
 					if(param.toUpperCase() === 'PREF') {
+						pref = prop.value;
 						found = true; //
 						break;
 					}


### PR DESCRIPTION
Contacts list was ignoring 'preferred' option, always displaying first email / phone
