### PR TITLE
Contacts: Issue #600 partial fix.

### DIFF
--- a/lib/searchprovider.php
+++ b/lib/searchprovider.php
@@ -12,29 +12,25 @@ namespace OCA\Contacts;
 
 class SearchProvider extends \OC_Search_Provider{
 	public function search($query) {
-		$unescape = function($value) {
-			return strtr($value, array('\,' => ',', '\;' => ';'));
-		};
 
 		$searchresults = array();
 		$results = \OCP\Contacts::search($query, array('N', 'FN', 'EMAIL', 'NICKNAME', 'ORG'));
 		$l = new \OC_l10n('contacts');
 		foreach($results as $result) {
 			$link = \OCP\Util::linkToRoute('contacts_index').'#' . $result['id'];
-			$props = array();
-			$display = (isset($result['FN']) && $result['FN']) ? $result['FN'] : null;
-			foreach(array('EMAIL', 'NICKNAME', 'ORG') as $searchvar) {
-				if(isset($result[$searchvar]) && $result[$searchvar]) {
-					if(is_array($result[$searchvar])) {
-						$result[$searchvar] = array_filter($result[$searchvar]);
+
+			$get = function($k) use($result) {
+				if (isset($result[$k]) && ($v = $result[$k])) {
+					if (is_array($v)) {
+						$v = implode(',', array_filter($v));
 					}
-					$prop = is_array($result[$searchvar]) ? implode(',', $result[$searchvar]) : $result[$searchvar];
-					$props[] = $prop;
-					$display = $display ?: $result[$searchvar];
-				}
-			}
-			$props = array_map($unescape, $props);
-			$searchresults[]=new \OC_Search_Result($display, implode(', ', $props), $link, (string)$l->t('Contact'), null);//$name,$text,$link,$type
+					return trim($v);
+				};
+				return null;
+			};
+
+			$display = $get('N') ?: $get('FN') ?: $get('NICKNAME') ?: $get('EMAIL');
+			$searchresults[]=new \OC_Search_Result($result['id'], $display, $link, (string)$l->t('Contact'));
 		}
 		return $searchresults;
 	}


### PR DESCRIPTION
It can sometimes be caused by the search provider ajax result set formatting issue, since the arguments are not in the correct order or the display name being null or an empty string depending on the user data, which leads to an unselectable row in search results
