### PR TITLE
Fix circular structure typeerror in chromium(38)

### DIFF
--- a/js/contacts.js
+++ b/js/contacts.js
@@ -330,6 +330,7 @@ OC.Contacts = OC.Contacts || {};
 
 	Contact.prototype.deleteProperty = function(params) {
 		var obj = params.obj;
+		params = {};
 		if(!this.enabled) {
 			return;
 		}


### PR DESCRIPTION
The variable `params` contains the member `obj` which does not seem to be of interest by the server. In chromium, this obj - member leads to an `Uncaught TypeError: Converting circular structure to JSON` when calling `JSON.stringify` for `params` in the `storage.patchContact(...)` function. There might be some other points within the code with the same problem, but I didn't find any on the fly.
