### PR TITLE
Fix 404 contact not found with shared addressbook

### DIFF
--- a/lib/addressbookprovider.php
+++ b/lib/addressbookprovider.php
@@ -287,18 +287,4 @@ SQL;
 		return $result;
 	}
 
-	private function getAddresbookKeyForContact($id){
-		$table = self::CONTACT_TABLE;
-		$query = <<<SQL
-			SELECT
-				`addressbookid`
-			FROM
-				`$table`
-			WHERE `id` = ?
-SQL;
-		$stmt = \OCP\DB::prepare($query);
-		$result = $stmt->execute(array($id));
-		$row = $result->fetchOne();
-		return $row['addressbookid'];
-	}
 }

--- a/lib/addressbookprovider.php
+++ b/lib/addressbookprovider.php
@@ -34,6 +34,7 @@ class AddressbookProvider implements \OCP\IAddressBook {
 
 	const CONTACT_TABLE = '*PREFIX*contacts_cards';
 	const PROPERTY_TABLE = '*PREFIX*contacts_cards_properties';
+	const ADDRESSBOOK_TABLE = '*PREFIX*contacts_addressbooks';
 
 	/**
 	 * Addressbook id
@@ -92,23 +93,32 @@ class AddressbookProvider implements \OCP\IAddressBook {
 	public function search($pattern, $searchProperties, $options) {
 		$propTable = self::PROPERTY_TABLE;
 		$contTable = self::CONTACT_TABLE;
+		$addrTable = self::ADDRESSBOOK_TABLE;
 		$results = array();
+
+		/**
+		 * This query will fetch all contacts which match the $searchProperties
+		 * It will look up the addressbookid of the contact and the user id of the owner of the contact app
+		 */
 		$query = <<<SQL
 			SELECT
 				DISTINCT
 				`$propTable`.`contactid`,
-				`$contTable`.`addressbookid`
+				`$contTable`.`addressbookid`,
+				`$addrTable`.`userid`
+
 			FROM
 				`$propTable`
 			INNER JOIN
 				`$contTable`
 			ON `$contTable`.`id` = `$propTable`.`contactid`
+  				INNER JOIN `$addrTable`
+			ON `$addrTable`.id = `$contTable`.addressbookid
 			WHERE
-			  `$propTable`.`userid` = ?
-			AND (
+			(
 SQL;
 
-		$params = array(\OCP\User::getUser());
+		$params = array();
 		foreach ($searchProperties as $property) {
 			$params[] = $property;
 			$params[] = '%' . $pattern . '%';
@@ -127,28 +137,38 @@ SQL;
 		while ($row = $result->fetchRow()) {
 			$id = $row['contactid'];
 			$addressbookKey = $row['addressbookid'];
-			try {
-				// gues that it is a local addressbook
-				$contact = $this->app->getContact('local', $addressbookKey, $id);
-			} catch (\Exception $e) {
-				if ($e->getCode() === 404) {
-					// not a local thus it is a shared
+			// Check if we are the owner of the contact
+			if ($row['userid'] !== \OCP\User::getUser()) {
+				// we aren't the owner of the contact
+				try {
+					// it is possible that the contact is shared with us
+					// if so, $contact will be an object
+					// if not getContact will throw an Exception
 					$contact = $this->app->getContact('shared', $addressbookKey, $id);
+				} catch (\Exception $e){
+					// the contact isn't shared with us
+					$contact = null;
 				}
+			} else {
+				// We are the owner of the contact
+				// thus we can easily fetch it
+				$contact = $this->app->getContact('local', $addressbookKey, $id);
 			}
-			$j = JSONSerializer::serializeContact($contact);
-			$j['data']['id'] = $id;
-			if (isset($contact->PHOTO)) {
-				$url = \OCP\Util::linkToRoute('contacts_contact_photo',
-					array(
-						'backend' => $contact->getBackend()->name,
-						'addressBookId' => $this->addressBook->getId(),
-						'contactId' => $contact->getId()
-					));
-				$url = \OC_Helper::makeURLAbsolute($url);
-				$j['data']['PHOTO'] = "VALUE=uri:$url";
+			if ($contact !== null) {
+				$j = JSONSerializer::serializeContact($contact);
+				$j['data']['id'] = $id;
+				if (isset($contact->PHOTO)) {
+					$url = \OCP\Util::linkToRoute('contacts_contact_photo',
+						array(
+							'backend' => $contact->getBackend()->name,
+							'addressBookId' => $addressbookKey,
+							'contactId' => $contact->getId()
+						));
+					$url = \OC_Helper::makeURLAbsolute($url);
+					$j['data']['PHOTO'] = "VALUE=uri:$url";
+				}
+				$results[] = $this->convertToSearchResult($j);
 			}
-			$results[] = $this->convertToSearchResult($j);
 		}
 		return $results;
 	}

--- a/lib/addressbookprovider.php
+++ b/lib/addressbookprovider.php
@@ -206,7 +206,6 @@ SQL;
 					break;
 				case 'EMAIL':
 				case 'TEL':
-				case 'TEL':
 				case 'IMPP': // NOTE: We don't know if it's GTalk, Jabber etc. only the protocol
 				case 'URL':
 					if(is_array($value)) {


### PR DESCRIPTION
There are again 404 occuring, this time with a shared addressbook. The contacts app tries to search for a contact in a `local` addressbook, but it fails because the addressbook isn't owned by this user. Instead it should access the same addressbook but not by using the `local` backend but the `shared` backend.

Refs https://github.com/owncloud/chat/issues/159#issuecomment-63945487

Note that this solution is a hack! In the DB there isn't a field which backend is used for this contact, thus we should guess this. Luckily the contact id is unique -> there can't be a match in the local addressbook when the contact is stored in the shared addressbook.
