### PR TITLE
Fix vendor_script not found

### DIFF
--- a/lib/compat.php
+++ b/lib/compat.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Copyright (c) 2014, Tobia De Koninck hey--at--ledfan.be
+ * This file is licensed under the AGPL version 3 or later.
+ * See the COPYING file.
+ */
+
+if(!function_exists('vendor_script')){
+	function vendor_script($app, $files){
+		if(is_array($files)) {
+			foreach($files as $file) {
+				\OCP\Util::addScript('contacts', '../vendor/' . $file);
+			}
+		} else {
+			\OCP\Util::addScript('contacts', '../vendor/' . $files);
+		}
+	}
+}
+
+if(!function_exists('vendor_style')){
+	function vendor_style($app, $files){
+		if(is_array($files)) {
+			foreach($files as $file) {
+				\OCP\Util::addStyle('contacts', '../vendor/' . $file);
+			}
+		} else {
+			\OCP\Util::addStyle('contacts', '../vendor/' . $files);
+		}
+	}
+}
+

--- a/templates/contacts.php
+++ b/templates/contacts.php
@@ -1,6 +1,8 @@
 <?php
 use OCA\Contacts\ImportManager;
 
+require_once(__DIR__ . "/../lib/compat.php");
+
 script('', array(
 	'tags',
 	'placeholder',


### PR DESCRIPTION
Fixs #727 
Note that this issue only happens when you are using `master` contacts and `stable7` ownCloud.
