### PR TITLE
fix auto escaping functionality of t()

### DIFF
--- a/js/groups.js
+++ b/js/groups.js
@@ -530,7 +530,7 @@ OC.Contacts = OC.Contacts || {};
 				if(self.hasGroup(newname, owner)) {
 					$(document).trigger('status.contacts.error', {
 						error: true,
-						message: t('contacts', 'A group named "{group}" already exists', {group: escapeHTML(newname)})
+						message: t('contacts', 'A group named "{group}" already exists', {group: newname})
 					});
 					return;
 				}
@@ -610,7 +610,7 @@ OC.Contacts = OC.Contacts || {};
 		var self = this;
 		if(this.hasGroup(name, OC.currentUser)) {
 			if(typeof cb === 'function') {
-				cb({error:true, message:t('contacts', 'A group named "{group}" already exists', {group: escapeHTML(name)})});
+				cb({error:true, message:t('contacts', 'A group named "{group}" already exists', {group: name})});
 			}
 			return;
 		}


### PR DESCRIPTION
Because of https://github.com/owncloud/core/pull/12687

Fully backwards compatible format. Once all supported platforms (that this version of the contacts app should run on) are using the autoescaping, this can be done via the build in auto escaping functionality of t().

cc @babelouest @jbtbnl

@LukasReschke @PVince81 @karlitschek Example of fully backwards compatible version for this change 
