### PR TITLE
in oc8 or later share_backend need to implement isShareTypeAllowed()

### DIFF
--- a/lib/share/addressbook.php
+++ b/lib/share/addressbook.php
@@ -127,4 +127,8 @@ class Addressbook implements \OCP\Share_Backend_Collection {
 		return $children;
 	}
 
+	public function isShareTypeAllowed($shareType) {
+		return true;
+	}
+
 }

--- a/lib/share/contact.php
+++ b/lib/share/contact.php
@@ -72,4 +72,8 @@ class Contact implements \OCP\Share_Backend {
 		return $contacts;
 	}
 
+	public function isShareTypeAllowed($shareType) {
+		return true;
+	}
+
 }


### PR DESCRIPTION
share_backend was extended by isShareTypeAllowed here: https://github.com/owncloud/core/pull/12749

Will be needed after the PR on core was merged

fix #745 
