### PR TITLE
Use thumbnail cache instead of refreshing every time

### DIFF
--- a/lib/utils/properties.php
+++ b/lib/utils/properties.php
@@ -293,11 +293,18 @@ Class Properties {
 		$cache = \OC::$server->getCache();
 		$key = self::THUMBNAIL_PREFIX . $backendName . '::' . $addressBookId . '::' . $contactId;
 		//$cache->remove($key);
-		if ($cache->hasKey($key) && $image === null
-			&& (isset($options['remove']) && $options['remove'] === false)
-			&& (isset($options['update']) && $options['update'] === false)) {
-			return $cache->get($key);
+		$haskey = $cache->hasKey($key);
+
+		if (!array_key_exists($options, 'remove') && !array_key_exists($options, 'update')){
+			if ($cache->hasKey($key) && $image === null){
+				return $cache->get($key);
+			}
+		} else {
+			if ($options['remove'] === false && $options['update'] === false){
+				return $cache->get($key);
+			}
 		}
+
 
 		if (isset($options['remove']) && $options['remove']) {
 			$cache->remove($key);

--- a/lib/utils/properties.php
+++ b/lib/utils/properties.php
@@ -295,7 +295,7 @@ Class Properties {
 		//$cache->remove($key);
 		$haskey = $cache->hasKey($key);
 
-		if (!array_key_exists($options, 'remove') && !array_key_exists($options, 'update')){
+		if (!array_key_exists('remove', $options) && !array_key_exists('update', $options)){
 			if ($cache->hasKey($key) && $image === null){
 				return $cache->get($key);
 			}


### PR DESCRIPTION
There was a bug in the contacts app #741 
This means that every time the contacts app is loaded the cache was updated, instead of fetching the thumbnail from the cache.

@Gomez does this fix issue #741 and https://github.com/owncloud/chat/issues/173 + the slowness of the Chat app? 
