### PR TITLE
require OC 7.8 not 8, or we don't work with current master

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,7 +4,7 @@
 	<name>Contacts</name>
 	<licence>AGPL</licence>
 	<author>Jakob Sack,Thomas Tanghus</author>
-	<require>8</require>
+	<require>7.8</require>
 	<shipped>true</shipped>
 	<description>Address book with CardDAV support.</description>
 	<standalone/>


### PR DESCRIPTION
core has its version set to x.8.y before pre-releases start shipping, then x.9.y when pre-releases are shipping; requiring 8 means the app is disabled until much later.
