### PR TITLE
add confirmation before deleting an addressbook

### DIFF
--- a/js/addressbooks.js
+++ b/js/addressbooks.js
@@ -62,9 +62,14 @@ OC.Contacts = OC.Contacts || {};
 				}
 			));
 		this.$li.find('a.action.delete').on('click keypress', function() {
-			$('.tipsy').remove();
-			console.log('delete', self.getId());
-			self.destroy();
+			OC.dialogs.confirm(t('contacts', 'Are you sure you want to delete the addressbook {addressbook} ?', {addressbook: self.getDisplayName()}),
+					t('contacts', 'Remove addressbook'), function(answer) {
+				if (answer) {
+					$('.tipsy').remove();
+					console.log('delete', self.getId());
+					self.destroy();
+				}
+			});
 		});
 		this.$li.find('a.action.carddav').on('click keypress', function() {
 			var uri = (self.book.owner === oc_current_user ) ? self.book.uri : self.book.uri + '_shared_by_' + self.book.owner;


### PR DESCRIPTION
new proposition for a addressbook deletion confirmation.
Got the inspiration from @rehrumesh 's work: https://github.com/owncloud/contacts/pull/787
but replaced the classic confirmation dialog by the owncloud one.
