### PR TITLE
Restrict addressbookprovider-search to its address-book to fix duplicate search results

### DIFF
--- a/lib/addressbookprovider.php
+++ b/lib/addressbookprovider.php
@@ -115,10 +115,12 @@ class AddressbookProvider implements \OCP\IAddressBook {
   				INNER JOIN `$addrTable`
 			ON `$addrTable`.id = `$contTable`.addressbookid
 			WHERE
-			(
+				(`$contTable`.addressbookid = ?) AND
+				(
 SQL;
 
 		$params = array();
+		$params[] = $this->addressBook->getMetaData()['id'];		
 		foreach ($searchProperties as $property) {
 			$params[] = $property;
 			$params[] = '%' . $pattern . '%';


### PR DESCRIPTION
This pull request solves two issues:
- contacts were displayed multiple times in the search results, when more than one address-book is available.
- the search result contained contacts of in-active address-books. (also multiplied by the number of address-books available to the user.)

Not sure if I have to file a bug. I tried this patch with 7.0.4 only and ported it to master with the github text-editor. To run a simple test of the patched code, search for existing and not-existing contacts with at least one address-book available.
