### PR TITLE
Register maintenance mode plugin

### DIFF
--- a/appinfo/remote.php
+++ b/appinfo/remote.php
@@ -68,6 +68,7 @@ $server = new \Sabre\DAV\Server($nodes);
 $server->httpRequest->setUrl(\OC::$server->getRequest()->getRequestUri());
 $server->setBaseUri($baseuri);
 // Add plugins
+$server->addPlugin(new \OC\Connector\Sabre\MaintenancePlugin());
 $server->addPlugin(new \Sabre\DAV\Auth\Plugin($authBackend, 'ownCloud'));
 $server->addPlugin(new OCA\Contacts\CardDAV\Plugin());
 $server->addPlugin(new \Sabre\DAVACL\Plugin());


### PR DESCRIPTION
Prevents remote.php to be used in maintenance mode

Please review @MorrisJobke @LukasReschke @LEDfan

Fixes https://github.com/owncloud/contacts/issues/874
