### PR TITLE
Make birthday events non-blocking

### DIFF
--- a/lib/contact.php
+++ b/lib/contact.php
@@ -837,6 +837,7 @@ class Contact extends VObject\VCard implements IPIMObject {
 			$vevent->{'UID'} = $this->UID;
 			$vevent->{'RRULE'} = 'FREQ=YEARLY';
 			$vevent->{'SUMMARY'} = $title . ' (' . $date->format('Y') . ')';
+			$vevent->{'TRANSP'} = 'TRANSPARENT';
 			$appinfo = \OCP\App::getAppInfo('contacts');
 			$appversion = \OCP\App::getAppVersion('contacts');
 			$vcal->PRODID = '-//ownCloud//NONSGML '.$appinfo['name'].' '.$appversion.'//EN';


### PR DESCRIPTION
Currently birthdays are blocking an entire day on calendars.

This patch utilizes the "TRANSP" property of RFC 2445 (4.8.2.7 Time Transparency) to change this behaviour.

Change works as expected on Windows Phone 8.1, no conflicts with other events on the same day are shown.
