### PR TITLE
Fix creation of ics files

### DIFF
--- a/lib/contact.php
+++ b/lib/contact.php
@@ -832,7 +832,7 @@ class Contact extends VObject\VCard implements IPIMObject {
 			$vevent->DTSTART->setDateTime(
 				$date
 			);
-			$event->DTSTART['VALUE'] = 'date';
+			$vevent->DTSTART['VALUE'] = 'date';
 			$vevent->add('DURATION', 'P1D');
 			$vevent->{'UID'} = $this->UID;
 			$vevent->{'RRULE'} = 'FREQ=YEARLY';


### PR DESCRIPTION
There was a wrong variable name in contacts.php

Please test this PR as I can not do this at the moment. The ics file should contain one line similar to this:

```
DTSTART;VALUE=DATE:20070628
```

For more information on that matter search RFC 5545 for "VALUE=DATE"
