### PR TITLE
Added german entry names for outlook-csv importer

### DIFF
--- a/formats/import_csv_outlook_connector.xml
+++ b/formats/import_csv_outlook_connector.xml
@@ -81,6 +81,7 @@ author: Nicolas Mora mail@babelouest.org
 	
 	<import_entry name="Last Name" enabled="true">
 		<altname lang="fr">Nom</altname>
+		<altname lang="de">Nachname</altname>
 		<vcard_entry property="N" position="0">
 		</vcard_entry>
 		<vcard_entry property="FN" position="1" separator=" ">
@@ -89,6 +90,7 @@ author: Nicolas Mora mail@babelouest.org
 	
 	<import_entry name="First Name" enabled="true">
 		<altname lang="fr">Prénom</altname>
+		<altname lang="de">Vorname</altname>
 		<vcard_entry property="N" position="1">
 		</vcard_entry>
 		<vcard_entry property="FN" position="0" separator=" ">
@@ -97,279 +99,326 @@ author: Nicolas Mora mail@babelouest.org
 	
 	<import_entry name="Middle Name" enabled="true">
 		<altname lang="fr">Deuxième prénom</altname>
+		<altname lang="de">Weitere Vornamen</altname>
 		<vcard_entry property="N" position="2">
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Title" enabled="true">
 		<altname lang="fr">Titre</altname>
+		<altname lang="de">Anrede</altname>
 		<vcard_entry property="N" position="3">
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Suffix" enabled="true">
 		<altname lang="fr">Suffixe</altname>
+		<altname lang="de">Suffix</altname>
 		<vcard_entry property="N" position="4">
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Company" enabled="true">
 		<altname lang="fr">Société</altname>
+		<altname lang="de">Firma</altname>
 		<vcard_entry property="ORG" >
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Job Title" enabled="true">
 		<altname lang="fr">Profession</altname>
+		<altname lang="de">Position</altname>
 		<vcard_entry property="TITLE" >
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Business Address PO Box" enabled="true">
 		<altname lang="fr">B.P. professionnelle</altname>
+		<altname lang="de">Postfach geschäftlich</altname>
 		<vcard_entry property="ADR" type="WORK" position="1" >
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Business Street" enabled="true">
 		<altname lang="fr">Rue (bureau)</altname>
+		<altname lang="de">Straße geschäftlich</altname>
 		<vcard_entry property="ADR" type="WORK" position="2" >
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Business City" enabled="true">
 		<altname lang="fr">Ville (bureau)</altname>
+		<altname lang="de">Ort geschäftlich</altname>
 		<vcard_entry property="ADR" type="WORK" position="3" >
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Business State" enabled="true">
 		<altname lang="fr">Dép/Région (bureau)</altname>
+		<altname lang="de">Region geschäftlich</altname>
 		<vcard_entry property="ADR" type="WORK" position="4" >
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Business Postal Code" enabled="true">
 		<altname lang="fr">Code postal (bureau)</altname>
+		<altname lang="de">Postleitzahl geschäftlich</altname>
 		<vcard_entry property="ADR" type="WORK" position="5" >
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Business Country" enabled="true">
 		<altname lang="fr">Pays/Région (bureau)</altname>
+		<altname lang="de">Land/Region geschäftlich</altname>
 		<vcard_entry property="ADR" type="WORK" position="6" >
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Home Address PO Box" enabled="true">
 		<altname lang="fr">Boîte postale du domicile</altname>
+		<altname lang="de">Postfach privat</altname>
 		<vcard_entry property="ADR" type="HOME" position="1" >
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Home Street" enabled="true">
 		<altname lang="fr">Rue (domicile)</altname>
+		<altname lang="de">Straße privat</altname>
 		<vcard_entry property="ADR" type="HOME" position="2" >
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Home City" enabled="true">
 		<altname lang="fr">Ville (domicile)</altname>
+		<altname lang="de">Ort privat</altname>
 		<vcard_entry property="ADR" type="HOME" position="3" >
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Home State" enabled="true">
 		<altname lang="fr">Dép/Région (domicile)</altname>
+		<altname lang="de">Bundesland/Kanton privat</altname>
 		<vcard_entry property="ADR" type="HOME" position="4" >
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Home Postal Code" enabled="true">
 		<altname lang="fr">Code postal (domicile)</altname>
+		<altname lang="de">Postleitzahl privat</altname>
 		<vcard_entry property="ADR" type="HOME" position="5" >
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Home Country" enabled="true">
 		<altname lang="fr">Pays/Région (domicile)</altname>
+		<altname lang="de">Land/Region privat</altname>
 		<vcard_entry property="ADR" type="HOME" position="6" >
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Business Fax" enabled="true">
 		<altname lang="fr">Télécopie (bureau)</altname>
+		<altname lang="de">Fax geschäftlich</altname>
 		<vcard_entry property="TEL" type="WORK,FAX">
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Business Phone" enabled="true">
 		<altname lang="fr">Téléphone (bureau)</altname>
+		<altname lang="de">Telefon geschäftlich</altname>
 		<vcard_entry property="TEL" type="WORK">
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Business Phone 2" enabled="true">
 		<altname lang="fr">Téléphone 2 (bureau)</altname>
+		<altname lang="de">Telefon geschäftlich 2</altname>
 		<vcard_entry property="TEL" type="WORK" group="businessphone2">
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Callback" enabled="true">
 		<altname lang="fr">Rappel</altname>
+		<altname lang="de">Rückmeldung</altname>
 		<vcard_entry property="TEL" type="CALLBACK">
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Car Phone" enabled="true">
 		<altname lang="fr">Téléphone (voiture)</altname>
+		<altname lang="de">Autotelefon</altname>
 		<vcard_entry property="TEL" type="CAR">
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Company Main Phone" enabled="true">
 		<altname lang="fr">Téléphone société</altname>
+		<altname lang="de">Telefon Firma</altname>
 		<vcard_entry property="TEL" type="WORK" group="companymainphone">
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Home Fax" enabled="true">
 		<altname lang="fr">Télécopie (domicile)</altname>
+		<altname lang="de">Fax privat</altname>
 		<vcard_entry property="TEL" type="HOME,FAX">
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Home Phone" enabled="true">
 		<altname lang="fr">Téléphone (domicile)</altname>
+		<altname lang="de">Telefon (privat)</altname>
 		<vcard_entry property="TEL" type="HOME" >
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Home Phone 2" enabled="true">
 		<altname lang="fr">Téléphone 2 (domicile)</altname>
+		<altname lang="de">Telefon (privat 2)</altname>
 		<vcard_entry property="TEL" type="HOME" group="homephone2">
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="ISDN" enabled="true">
 		<altname lang="fr">RNIS</altname>
+		<altname lang="de">ISDN</altname>
 		<vcard_entry property="TEL" type="ISDN" >
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Mobile Phone" enabled="true">
 		<altname lang="fr">Tél. mobile</altname>
+		<altname lang="de">Mobiltelefon</altname>
 		<vcard_entry property="TEL" type="CELL" >
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Other Fax" enabled="true">
 		<altname lang="fr">Télécopie (autre)</altname>
+		<altname lang="de">Weiteres Fax </altname>
 		<vcard_entry property="TEL" type="FAX,OTHER" >
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Other Phone" enabled="true">
 		<altname lang="fr">Téléphone (autre)</altname>
+		<altname lang="de">Weiteres Telefon </altname>
 		<vcard_entry property="TEL" type="HOME,OTHER" >
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Pager" enabled="true">
 		<altname lang="fr">Récepteur de radiomessagerie</altname>
+		<altname lang="de">Pager</altname>
 		<vcard_entry property="TEL" type="PAGER" >
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Primary Phone" enabled="true">
 		<altname lang="fr">Téléphone principal</altname>
+		<altname lang="de">Haupttelefon</altname>
 		<vcard_entry property="TEL" >
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Anniversary" enabled="true">
 		<altname lang="fr">Anniversaire de mariage ou fête</altname>
+		<altname lang="de">Jahrestag</altname>
 		<vcard_entry property="ANNIVERSARY" >
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Assistant's Name" enabled="true">
 		<vcard_entry property="RELATED" type="assistant">
+		<altname lang="de">Assistent(in)</altname>
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Manager's Name" enabled="true">
 		<altname lang="fr">Responsable</altname>
+		<altname lang="de">Name des/r Vorgesetzten</altname>
 		<vcard_entry property="RELATED" type="manager">
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Birthday" enabled="true">
 		<altname lang="fr">Anniversaire</altname>
+		<altname lang="de">Geburtstag</altname>
 		<vcard_entry property="BDAY" >
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Categories" enabled="true">
 		<altname lang="fr">Catégories</altname>
+		<altname lang="de">Kategorien</altname>
 		<vcard_entry property="CATEGORIES" >
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Children" enabled="true">
 		<altname lang="fr">Enfants</altname>
+		<altname lang="de">Kinder</altname>
 		<vcard_entry property="RELATED" type="child" >
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Spouse" enabled="true">
 		<altname lang="fr">Conjoint(e)</altname>
+		<altname lang="de">Partner</altname>
 		<vcard_entry property="RELATED" type="spouse" >
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="E-mail Address" enabled="true">
 		<altname lang="fr">Adresse de messagerie</altname>
+		<altname lang="de">E-Mail-Adresse</altname>
 		<vcard_entry property="EMAIL" >
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="E-mail 2 Address" enabled="true">
 		<altname lang="fr">Adresse de messagerie 2</altname>
+		<altname lang="de">E-Mail 2: Adresse</altname>
 		<vcard_entry property="EMAIL" group="email2" >
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="E-mail 3 Address" enabled="true">
 		<altname lang="fr">Adresse de messagerie 3</altname>
+		<altname lang="de">E-Mail 3: Adresse</altname>
 		<vcard_entry property="EMAIL" group="email3" >
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Gender" enabled="true">
+		<altname lang="de">Geschlecht</altname>
 		<vcard_entry property="GENDER" >
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Initials" enabled="true">
 		<altname lang="fr">Initiales</altname>
+		<altname lang="de">Initialen</altname>
 		<vcard_parameter property="N" parameter="initials">
 		</vcard_parameter>
 	</import_entry>
 	
 	<import_entry name="Language" enabled="true">
 		<altname lang="fr">Langue</altname>
+		<altname lang="de">Sprache</altname>
 		<vcard_parameter property="LANG" >
 		</vcard_parameter>
 	</import_entry>
 	
 	<import_entry name="Notes" enabled="true">
+		<altname lang="de">Notizen</altname>
 		<vcard_parameter property="NOTE" >
 		</vcard_parameter>
 	</import_entry>
 	
 	<import_entry name="User 2" enabled="true">
 		<altname lang="fr">Utilisateur 2</altname>
+		<altname lang="de">Benutzer 2</altname>
 		<vcard_entry property="IMPP" prefix="msn:">
 			<additional_property name="X-SERVICE-TYPE" value="msn" />
 		</vcard_entry>
@@ -377,6 +426,7 @@ author: Nicolas Mora mail@babelouest.org
 	
 	<import_entry name="Website" enabled="true">
 		<altname lang="fr">Page Web</altname>
+		<altname lang="de">Webseite</altname>
 		<vcard_entry property="URL" >
 		</vcard_entry>
 	</import_entry>

--- a/formats/import_csv_outlook_connector.xml
+++ b/formats/import_csv_outlook_connector.xml
@@ -268,6 +268,7 @@ author: Nicolas Mora mail@babelouest.org
 	<import_entry name="Home Phone" enabled="true">
 		<altname lang="fr">Téléphone (domicile)</altname>
 		<altname lang="de">Telefon (privat)</altname>
+		<altname lang="de">Telefon privat</altname>
 		<vcard_entry property="TEL" type="HOME" >
 		</vcard_entry>
 	</import_entry>
@@ -275,6 +276,7 @@ author: Nicolas Mora mail@babelouest.org
 	<import_entry name="Home Phone 2" enabled="true">
 		<altname lang="fr">Téléphone 2 (domicile)</altname>
 		<altname lang="de">Telefon (privat 2)</altname>
+		<altname lang="de">Telefon privat 2</altname>
 		<vcard_entry property="TEL" type="HOME" group="homephone2">
 		</vcard_entry>
 	</import_entry>
@@ -331,12 +333,14 @@ author: Nicolas Mora mail@babelouest.org
 	<import_entry name="Assistant's Name" enabled="true">
 		<vcard_entry property="RELATED" type="assistant">
 		<altname lang="de">Assistent(in)</altname>
+		<altname lang="de">Name Assistent</altname>
 		</vcard_entry>
 	</import_entry>
 	
 	<import_entry name="Manager's Name" enabled="true">
 		<altname lang="fr">Responsable</altname>
 		<altname lang="de">Name des/r Vorgesetzten</altname>
+		<altname lang="de">Name des/der Vorgesetzten</altname>
 		<vcard_entry property="RELATED" type="manager">
 		</vcard_entry>
 	</import_entry>


### PR DESCRIPTION
As of csv field names beeing localized, the importer was only abled to import csv files from english and french versions of outlook.  
With this little change, also german versions will be supported. Source for my altnames was an dummy export from outlook 2013. Tested with Owncloud 8.0.
