### PR TITLE
Fix standard vcard import

### DIFF
--- a/lib/controller/importcontroller.php
+++ b/lib/controller/importcontroller.php
@@ -125,7 +125,7 @@ class ImportController extends Controller {
 			$view->mkdir('imports');
 		}
 
-		$content = \OC_Filesystem::file_get_contents($path . '/' . $filename);
+		$content = \OC\Files\Filesystem::file_get_contents($path . '/' . $filename);
 		if($view->file_put_contents('/imports/' . $filename, $content)) {
 			$progresskey = 'contacts-import-' . rand();
 			$response->setParams(
@@ -183,9 +183,9 @@ class ImportController extends Controller {
 		$file = $view->file_get_contents('/imports/' . $filename);
 
 		$importManager = new ImportManager();
-		
+
 		$formatList = $importManager->getTypes();
-		
+
 		$found = false;
 		$parts = array();
 		foreach ($formatList as $formatName => $formatDisplayName) {
@@ -194,7 +194,7 @@ class ImportController extends Controller {
 				$found = true;
 			}
 		}
-		
+
 		if (!$found) {
 			// detect file type
 			$mostLikelyName = "";
@@ -206,13 +206,13 @@ class ImportController extends Controller {
 					$mostLikelyValue = $probValue;
 				}
 			}
-			
+
 			if ($mostLikelyValue > 0) {
 				// found one (most likely...)
 				$parts = $importManager->importFile($view->getLocalFile('/imports/' . $filename), $mostLikelyName);
 			}
 		}
-		
+
 		if ($parts) {
 			//import the contacts
 			$imported = 0;


### PR DESCRIPTION
Fixes #566 in a way that that if you select standard vcard format the import works. This feature is crucial because if you initially start syncing most mobile OSes (looking at you iOS and Android) make it an absolute pain to copy contacts into a new group. The only way to do this is by exporting your contacts as vcard and importing them again.

This fix is not best practice, but it gets stuff working again. And lets be honest, almost the entirety of the controller needs to be refactored which takes too long to fix this simple issue. I'd say lets apply this fix and wait for some maintainer to rewrite huge portions of the app. Or simply kill the app if a better and maintained alternative is already around

@jancborchardt @LukasReschke @DeepDiver1975 @MorrisJobke @halfline
