### PR TITLE
Fixed error handling in getContact if  $id not an array.

### DIFF
--- a/lib/backend/shared.php
+++ b/lib/backend/shared.php
@@ -138,12 +138,12 @@ class Shared extends Database {
 		$card = parent::getContact($addressBookId, $id, $options);
 
 		if (!$card) {
-                        if (is_array($id)) {
-                                $idstr = implode(", ", $id);
-                        } else {
-                                $idstr = $id;
-                        }
-                        throw new \Exception('Shared Contact not found: ' . $idstr, 404);
+			if (is_array($id)) {
+				$idstr = implode(", ", $id);
+			} else {
+				$idstr = $id;
+			}
+			throw new \Exception('Shared Contact not found: ' . $idstr, 404);
 		}
 
 		$card['permissions'] = $permissions;

--- a/lib/backend/shared.php
+++ b/lib/backend/shared.php
@@ -138,7 +138,12 @@ class Shared extends Database {
 		$card = parent::getContact($addressBookId, $id, $options);
 
 		if (!$card) {
-			throw new \Exception('Shared Contact not found: ' . implode(',', $id), 404);
+                        if (is_array($id)) {
+                                $idstr = implode(", ", $id);
+                        } else {
+                                $idstr = $id;
+                        }
+                        throw new \Exception('Shared Contact not found: ' . $idstr, 404);
 		}
 
 		$card['permissions'] = $permissions;


### PR DESCRIPTION
I had some group<->contact associations in the oc_vcategory_to_object table for contacts that where no longer existing. The cause of these is another topic, but  it resulted in a lot of errors like this in the log, when I accessed the contacts app on the webpage:

> implode(): Invalid arguments passed at [...]/contacts/lib/backend/shared.php#139

I made the implode optional (only if $id is an array) to fix this error.
