### PR TITLE
fix app loading with avatars disabled

### DIFF
--- a/lib/controller/pagecontroller.php
+++ b/lib/controller/pagecontroller.php
@@ -42,6 +42,11 @@ class PageController extends Controller {
 
 		$maxUploadFilesize = \OCP\Util::maxUploadFilesize('/');
 
+		\OCP\Util::addScript('placeholder', null);
+		\OCP\Util::addScript('../vendor/blueimp-md5/js/md5', null);
+		\OCP\Util::addScript('jquery.avatar', null);
+		\OCP\Util::addScript('avatar', null);
+
 		$response = new TemplateResponse($this->appName, 'contacts');
 		$response->setParams(array(
 			'uploadMaxFilesize' => $maxUploadFilesize,


### PR DESCRIPTION
The contacts app fails to load with JavaScript errors, when avatars are disabled. I am not sure this is the proper fix, but as a workaround, it works for me.
