### PR TITLE
Fix PHP 5.3 compatibility

### DIFF
--- a/lib/addressbookprovider.php
+++ b/lib/addressbookprovider.php
@@ -120,7 +120,8 @@ class AddressbookProvider implements \OCP\IAddressBook {
 SQL;
 
 		$params = array();
-		$params[] = $this->addressBook->getMetaData()['id'];
+		$meta = $this->addressBook->getMetaData();
+		$params[] = $meta['id'];
 		foreach ($searchProperties as $property) {
 			$params[] = $property;
 			$params[] = '%' . $pattern . '%';


### PR DESCRIPTION
Regression caused by https://github.com/owncloud/contacts/pull/858 - without this ownCloud contacts is broken on PHP 5.3 (fatal PHP error + white page) - this affects stable7 and thus 7.0.7

@DeepDiver1975 @karlitschek Please review. THX.
