### PR TITLE
insert correct userid (aka id of owner) into index properties.

### DIFF
--- a/lib/hooks.php
+++ b/lib/hooks.php
@@ -104,6 +104,10 @@ class Hooks{
 
 	public static function contactAdded($parameters) {
 		\OCP\Util::writeLog('contacts', __METHOD__.' id: '.$parameters['id'], \OCP\Util::DEBUG);
+		$app = new App();
+		$backend = $app->getBackend( (isset($parameters['backend'])) ? $parameters['backend'] :'local' );
+		$ab = $backend->getAddressBook( $parameters['addressBookId'] );
+
 		$contact = $parameters['contact'];
 		if(isset($contact->CATEGORIES)) {
 			\OCP\Util::writeLog('contacts', __METHOD__.' groups: '.print_r($contact->CATEGORIES->getParts(), true), \OCP\Util::DEBUG);
@@ -113,13 +117,17 @@ class Hooks{
 				$tagMgr->tagAs($parameters['id'], $group);
 			}
 		}
-		Utils\Properties::updateIndex($parameters['id'], $contact);
+		Utils\Properties::updateIndex($parameters['id'], $contact, $ab['owner']);
 	}
 
 	public static function contactUpdated($parameters) {
 		//\OCP\Util::writeLog('contacts', __METHOD__.' parameters: '.print_r($parameters, true), \OCP\Util::DEBUG);
+		$app = new App();
+		$backend = $app->getBackend( (isset($parameters['backend'])) ? $parameters['backend'] :'local' );
+		$ab = $backend->getAddressBook( $parameters['addressBookId'] );
+
 		$contact = $parameters['contact'];
-		Utils\Properties::updateIndex($parameters['contactId'], $contact);
+		Utils\Properties::updateIndex($parameters['contactId'], $contact, $ab['owner']);
 		// If updated via CardDAV we don't know if PHOTO has changed
 		if(isset($parameters['carddav']) && $parameters['carddav']) {
 			if(isset($contact->PHOTO) || isset($contact->LOGO)) {

--- a/lib/utils/properties.php
+++ b/lib/utils/properties.php
@@ -252,12 +252,17 @@ Class Properties {
 	 *
 	 * @param string $contactId
 	 * @param VCard|null $vCard
+         * @param string|null $owner
 	 */
-	public static function updateIndex($contactId, $vCard = null) {
+	public static function updateIndex($contactId, $vCard = null, $owner = null) {
 		self::purgeIndexes(array($contactId));
 
 		if(is_null($vCard)) {
 			return;
+		}
+
+		if(is_null($owner) || empty($owner) ) {
+			$owner = \OC::$server->getUserSession()->getUser()->getUId();
 		}
 
 		if(!isset(self::$updateindexstmt)) {
@@ -278,7 +283,7 @@ Class Properties {
 			try {
 				$result = self::$updateindexstmt->execute(
 					array(
-						\OC::$server->getUserSession()->getUser()->getUId(),
+						$owner,
 						$contactId,
 						$property->name,
 						substr($property->getValue(), 0, 254),


### PR DESCRIPTION
The index table (oc_contacts_cards_properties) contains the userid of the owner of an entry, which is the owner of the addressbook of the card from which the index entry is taken from.
The updateIndex function, however, always puts in the user id of the current user. This is incorrect when an addressbook is shared allowing edits for others. Whenever a user changes something in a shared card the index entries are rewritten. This means the userid of an index table entry is in fact the user id of the last user editing the entry.
This commit extends updateIndex with a third argument which allows to pass the owner for that index entry which is used when a contact is added or updated.
