### PR TITLE
Fix birthday dtstamp

### DIFF
--- a/lib/contact.php
+++ b/lib/contact.php
@@ -779,6 +779,9 @@ class Contact extends VObject\VCard implements IPIMObject {
 			);
 			$vEvent->DTSTART['VALUE'] = 'date';
 			$vEvent->add('DURATION', 'P1D');
+			$lm = new \DateTime('@' . $this->lastModified());
+			$lm->setTimeZone(new \DateTimeZone('UTC'));
+			$vEvent->DTSTAMP->setDateTime($lm);
 			$vEvent->{'UID'} = $this->UID;
 			$vEvent->{'RRULE'} = 'FREQ=YEARLY';
 			$vEvent->{'SUMMARY'} = $title . ' (' . $date->format('Y') . ')';


### PR DESCRIPTION
If there is no DTSTAMP set in a calendar object it will automatically set to the current time. Due to this, birthday events are considered changed each time the client checks them.
With this change, DTSTAMP is set the time of last modification of the contact, thus clients won't think the birthday event has been changed unless the contact has been changed...
