### PR TITLE
Shorten display of contact's birthdays in Calendar

### DIFF
--- a/lib/contact.php
+++ b/lib/contact.php
@@ -791,7 +791,7 @@ class Contact extends VObject\VCard implements IPIMObject {
 		if ((string)$birthday) {
 			$title = str_replace('{name}',
 				strtr((string)$this->FN, array('\,' => ',', '\;' => ';')),
-				App::$l10n->t('{name}\'s Birthday')
+                		'{name}'
 			);
 			try {
 				$date = new \DateTime($birthday);
@@ -812,7 +812,8 @@ class Contact extends VObject\VCard implements IPIMObject {
 			$vEvent->DTSTAMP->setDateTime($lm);
 			$vEvent->{'UID'} = $this->UID;
 			$vEvent->{'RRULE'} = 'FREQ=YEARLY';
-			$vEvent->{'SUMMARY'} = $title . ' (' . $date->format('Y') . ')';
+			$bCake = (string)"\xf0\x9f\x8e\x82";
+			$vEvent->{'SUMMARY'} = $bCake . ' ' . $title . ' (' . $date->format('Y') . ')';
 			$vEvent->{'TRANSP'} = 'TRANSPARENT';
 			$appInfo = \OCP\App::getAppInfo('contacts');
 			$appVersion = \OCP\App::getAppVersion('contacts');


### PR DESCRIPTION
Replaces "birthday" with a UTF8 birthday cake;
works language independend;
also synchronizes well to PC and smartphone/tablet
https://github.com/owncloud/contacts/issues/1027
