### PR TITLE
Use uppercase DATE for property parameter VALUE

### DIFF
--- a/lib/contact.php
+++ b/lib/contact.php
@@ -786,8 +786,13 @@ class Contact extends VObject\VCard implements IPIMObject {
 			$vEvent->DTSTART->setDateTime(
 				$date
 			);
-			$vEvent->DTSTART['VALUE'] = 'date';
-			$vEvent->add('DURATION', 'P1D');
+			$vEvent->DTSTART['VALUE'] = 'DATE';
+			$vEvent->add('DTEND');
+			$date->add(new \DateInterval('P1D'));
+			$vEvent->DTEND->setDateTime(
+				$date
+			);
+			$vEvent->DTEND['VALUE'] = 'DATE';
 			$lm = new \DateTime('@' . $this->lastModified());
 			$lm->setTimeZone(new \DateTimeZone('UTC'));
 			$vEvent->DTSTAMP->setDateTime($lm);


### PR DESCRIPTION
as some clients expect uppercase.
Also use DTEND instead of DURATION as that seems how most client generate one-day events.
backport of #1046 
