### PR TITLE
Fix multi version and only upgrade 2.1 cards.

### DIFF
--- a/lib/connector/importvcardconnector.php
+++ b/lib/connector/importvcardconnector.php
@@ -143,7 +143,13 @@ class ImportVCardConnector extends ImportConnector{
 				}
 			} else {
 				$property = clone $sourceProperty;
-				$dest->add($property);
+				// VERSION and PRODID are set by default in any new empty vcard object.
+				// Thus it needs to be replaced instead of simply added as additional value.
+				if ( $property->name === 'PRODID' || $property->name === 'VERSION' ) {
+					$dest->__set($property->name, $property);
+				} else {
+					$dest->add($property);
+				}
 			}
 		}
 		

--- a/lib/contact.php
+++ b/lib/contact.php
@@ -70,7 +70,11 @@ class Contact extends VObject\VCard implements IPIMObject {
 		if (!is_null($data)) {
 			if ($data instanceof VObject\VCard) {
 				foreach ($data->children as $child) {
-					$this->add($child);
+					if($child->name === 'VERSION' || $child->name === 'PRODID') {
+						parent::__set($child->name, $child);
+					} else {
+						$this->add($child);
+					}
 				}
 				$this->setRetrieved(true);
 			} elseif (is_array($data)) {
@@ -324,7 +328,11 @@ class Contact extends VObject\VCard implements IPIMObject {
 			if(isset($this->props['vcard'])
 				&& $this->props['vcard'] instanceof VObject\VCard) {
 				foreach($this->props['vcard']->children() as $child) {
-					$this->add($child);
+					if($child->name === 'VERSION' || $child->name === 'PRODID') {
+						parent::__set($child->name, $child);
+					} else {
+						$this->add($child);
+					}
 					if($child->name === 'FN') {
 						$this->props['displayname']
 							= strtr($child->getValue(), array('\,' => ',', '\;' => ';', '\\\\' => '\\'));
@@ -344,7 +352,11 @@ class Contact extends VObject\VCard implements IPIMObject {
 					if (isset($result['vcard'])
 						&& $result['vcard'] instanceof VObject\VCard) {
 						foreach ($result['vcard']->children() as $child) {
-							$this->add($child);
+							if($child->name === 'VERSION' || $child->name === 'PRODID') {
+								parent::__set($child->name, $child);
+							} else {
+								$this->add($child);
+							}
 						}
 						$this->setRetrieved(true);
 						return true;


### PR DESCRIPTION
Due to overlap includes #1041 
When reading an importing card convertElementToVCard() simply copies all elements from the import card into a new empty vcard object. However, an empty vcard object by default has a VERSION and PRODID value set already. Due to this, convertElementToVCard() adds additional VERSION and PRODID values which shouldn't happen as both are allowed as most once.
Also the validate() function now checks for multiple VERSION values and removes all and sets it to the first one found.
