### PR TITLE
Fix multi version and only upgrade 2.1 cards.

### DIFF
--- a/lib/connector/importvcardconnector.php
+++ b/lib/connector/importvcardconnector.php
@@ -143,7 +143,13 @@ class ImportVCardConnector extends ImportConnector{
 				}
 			} else {
 				$property = clone $sourceProperty;
-				$dest->add($property);
+				// VERSION and PRODID are set by default in any new empty vcard object.
+				// Thus it needs to be replaced instead of simply added as additional value.
+				if ( $property->name === 'PRODID' || $property->name === 'VERSION' ) {
+					$dest->__set($property->name, $property);
+				} else {
+					$dest->add($property);
+				}
 			}
 		}
 		


### PR DESCRIPTION
Backport of #1054 
Make sure to replace PRODID and VERSION instead of adding
additional ones...

Only upgrade a vcard to 3.0 if it is 2.1.
Only set REV if something has been repaired.

If multiple VERSION values are set, remove all and set only the value
of the first.
If card has been repaired change PRODID to own appinfo.

satisfy Scrutinizer
