### PR TITLE
pass addressBookId as addressBookId, not parent

### DIFF
--- a/lib/backend/database.php
+++ b/lib/backend/database.php
@@ -635,7 +635,7 @@ class Database extends AbstractBackend {
 
 		$this->setModifiedAddressBook($addressBookId);
 		\OCP\Util::emitHook('OCA\Contacts', 'post_createContact',
-			array('id' => $newid, 'parent' => $addressBookId, 'backend' => $this->name, 'contact' => $contact)
+			array('id' => $newid, 'addressBookId' => $addressBookId, 'backend' => $this->name, 'contact' => $contact)
 		);
 		return (string)$newid;
 	}


### PR DESCRIPTION
fixes error message "Undefined index: addressBookId at /var/www/owncloud/apps/contacts/lib/hooks.php#109"
fix for #1127
